### PR TITLE
Align graph executor with current LaunchDarkly AI SDK

### DIFF
--- a/api/services/agent_service.py
+++ b/api/services/agent_service.py
@@ -137,7 +137,7 @@ class AgentGraphExecutor:
                     log_student(f"TERMINAL: {node_key}")
                     break
 
-                next_node = self._select_next_node(edges, result, nodes, graph_tracker)
+                next_node = self._select_next_node(edges, result, nodes, graph_tracker, source_key=node_key)
                 prev_node_key = node_key
                 current_node = next_node
 
@@ -153,7 +153,7 @@ class AgentGraphExecutor:
 
         return ctx
 
-    def _select_next_node(self, edges, result: dict, nodes: dict, graph_tracker=None):
+    def _select_next_node(self, edges, result: dict, nodes: dict, graph_tracker=None, source_key: str = ""):
         """Select next node based on agent result and edge handoffs."""
         routing = result.get("routing_decision", "").lower().strip() if result.get("routing_decision") else None
 
@@ -174,7 +174,7 @@ class AgentGraphExecutor:
         elif routing:
             log_student(f"  UNRECOGNIZED ROUTE: '{routing}' not in {list(route_map.keys())}")
             if graph_tracker:
-                graph_tracker.track_handoff_failure()
+                graph_tracker.track_handoff_failure(source_key, routing)
 
         # Default: first edge (fallback)
         if edges:


### PR DESCRIPTION
The AIGraphTracker public API in launchdarkly-server-sdk-ai main branch no longer exposes track_node_invocation or a two-arg track_tool_call, and track_handoff_failure now requires (source_key, target_key). The private _ld_client.track hack in _track_duration is obsolete now that AIGraphTracker.track_latency is public (and already used in _track_graph_metrics for total graph latency).

Changes:
- Drop track_node_invocation — method does not exist on AIGraphTracker
- Move tool call tracking to config.tracker.track_tool_call(tool_name, graph_key=graph_key), which is where the per-node tool metric lives
- Pass source_key through to _select_next_node so track_handoff_failure can be called with the required (source_key, routing) args
- Delete _track_duration — redundant with the existing config.tracker.track_duration call in generic_agent.ainvoke, and was reaching into graph_tracker._ld_client instead of using public API

Node-level latency still flows through each node's config.tracker. Graph-level latency already flows through _track_graph_metrics.track_latency.