### PR TITLE
Fix track_handoff_failure signature mismatch

### DIFF
--- a/api/services/agent_service.py
+++ b/api/services/agent_service.py
@@ -137,7 +137,7 @@ class AgentGraphExecutor:
                     log_student(f"TERMINAL: {node_key}")
                     break
 
-                next_node = self._select_next_node(edges, result, nodes, graph_tracker)
+                next_node = self._select_next_node(edges, result, nodes, graph_tracker, source_key=node_key)
                 prev_node_key = node_key
                 current_node = next_node
 
@@ -153,7 +153,7 @@ class AgentGraphExecutor:
 
         return ctx
 
-    def _select_next_node(self, edges, result: dict, nodes: dict, graph_tracker=None):
+    def _select_next_node(self, edges, result: dict, nodes: dict, graph_tracker=None, source_key: str = ""):
         """Select next node based on agent result and edge handoffs."""
         routing = result.get("routing_decision", "").lower().strip() if result.get("routing_decision") else None
 
@@ -174,7 +174,7 @@ class AgentGraphExecutor:
         elif routing:
             log_student(f"  UNRECOGNIZED ROUTE: '{routing}' not in {list(route_map.keys())}")
             if graph_tracker:
-                graph_tracker.track_handoff_failure()
+                graph_tracker.track_handoff_failure(source_key, routing)
 
         # Default: first edge (fallback)
         if edges:


### PR DESCRIPTION
AIGraphTracker.track_handoff_failure in launchdarkly-server-sdk-ai v0.16.0 requires (source_key: str, target_key: str). The existing zero-arg call at the unrecognized-route branch of _select_next_node would raise TypeError at runtime whenever an LLM returned a routing decision that did not match any outgoing edge.

Thread source_key through _select_next_node from the caller so both the source (the current node we are leaving) and the attempted-but-unrecognized route string are passed to the tracker.

No other changes — track_node_invocation, track_tool_call, track_handoff_success, track_latency, track_total_tokens, track_invocation_success, and _track_duration all continue to work as written.