### PR TITLE
fix: Modernize devrel agents tutorial to current Python AI SDK 0.20

### DIFF
--- a/agents/ld_agent_helpers.py
+++ b/agents/ld_agent_helpers.py
@@ -275,7 +275,7 @@ async def create_agent_with_fresh_config(
             prompt=agent_config.instructions
         )
 
-        return agent, agent_config.tracker, False, effective_recursion_limit
+        return agent, agent_config.create_tracker(), False, effective_recursion_limit
 
     except Exception as e:
         log_student(f"ERROR in create_agent_with_fresh_config: {e}")
@@ -355,8 +355,7 @@ def create_simple_agent_wrapper(config_manager, config_key: str, tools: List[Any
                     # Track success and latency
                     tracker.track_success()
                     latency_ms = int((time.time() - start_time) * 1000)
-                    if hasattr(tracker, 'track_latency_ms'):
-                        tracker.track_latency_ms(latency_ms)
+                    tracker.track_duration(latency_ms)
 
                     # Extract token usage from new messages
                     new_messages = response['messages'][prev_message_count:]

--- a/agents/security_agent.py
+++ b/agents/security_agent.py
@@ -112,6 +112,9 @@ def create_security_agent(agent_config, config_manager: ConfigManager):
                     "response": "Security check disabled"
                 }
 
+            # Create tracker for token, cost, and success/error metrics
+            tracker = agent_config.create_tracker()
+
             # Create model with structured output and up-to-date instructions
             from agents.ld_agent_helpers import map_provider_to_langchain, create_bedrock_chat_model
             from utils.bedrock_helpers import normalize_bedrock_provider
@@ -212,7 +215,7 @@ def create_security_agent(agent_config, config_manager: ConfigManager):
                         output=usage_data.get("output_tokens", 0),
                         total=usage_data.get("total_tokens", 0)
                     )
-                    agent_config.tracker.track_tokens(token_usage)
+                    tracker.track_tokens(token_usage)
                     log_student(f"SECURITY PII DETECTION TOKENS: {token_usage.total} tokens ({token_usage.input} in, {token_usage.output} out)")
 
                     # Track cost metric with AI Config metadata for experiment attribution
@@ -229,7 +232,7 @@ def create_security_agent(agent_config, config_manager: ConfigManager):
                         log_student(f"COST TRACKING: ${cost:.6f} for {agent_config.model.name}")
 
             # Track success metric
-            agent_config.tracker.track_success()
+            tracker.track_success()
 
             # Extract structured results
             detected = pii_result.detected
@@ -248,11 +251,11 @@ def create_security_agent(agent_config, config_manager: ConfigManager):
             }
             
         except Exception:
-            
+
             # Track error with LDAI metrics
             try:
-                if 'agent_config' in locals() and agent_config and hasattr(agent_config, 'tracker'):
-                    agent_config.tracker.track_error()
+                if 'agent_config' in locals() and agent_config:
+                    agent_config.create_tracker().track_error()
             except Exception:
                 pass
             

--- a/agents/supervisor_agent.py
+++ b/agents/supervisor_agent.py
@@ -119,10 +119,13 @@ def create_supervisor_agent(supervisor_config, support_config, security_config, 
     
     # Import needed modules for model creation
     from langchain.chat_models import init_chat_model
-    
+
     # Create child agents with config manager
     support_agent = create_support_agent(support_config, config_manager)
     security_agent = create_security_agent(security_config, config_manager)
+
+    # Create tracker for the supervisor's own LLM calls and orchestration metrics
+    supervisor_tracker = supervisor_config.create_tracker()
 
     log_debug(f"SUPERVISOR INSTRUCTIONS: {supervisor_config.instructions}")
 
@@ -217,7 +220,7 @@ def create_supervisor_agent(supervisor_config, support_config, security_config, 
                         output=usage_data.get("output_tokens", 0),
                         total=usage_data.get("total_tokens", 0)
                     )
-                    supervisor_config.tracker.track_tokens(token_usage)
+                    supervisor_tracker.track_tokens(token_usage)
                     log_student(f"PII PRESCREEN TOKENS: {token_usage.total} tokens ({token_usage.input} in, {token_usage.output} out)")
 
                     # Track cost metric with AI Config metadata for experiment attribution
@@ -234,7 +237,7 @@ def create_supervisor_agent(supervisor_config, support_config, security_config, 
                         log_student(f"COST TRACKING: ${cost:.6f} for {supervisor_config.model.name}")
 
             # Track success metric
-            supervisor_config.tracker.track_success()
+            supervisor_tracker.track_success()
 
             # Log the intelligent decision
             log_student(f"ROUTING: {screening_result.recommended_route} ({screening_result.confidence:.1f}) - {screening_result.reasoning}")
@@ -390,8 +393,7 @@ def create_supervisor_agent(supervisor_config, support_config, security_config, 
             
         except Exception as e:
             # Track error with LDAI metrics
-            if 'supervisor_config' in locals() and supervisor_config and hasattr(supervisor_config, 'tracker'):
-                supervisor_config.tracker.track_error()
+            supervisor_tracker.track_error()
 
             return {
                 "messages": [AIMessage(content=f"Security agent error: {e}")],
@@ -501,8 +503,7 @@ def create_supervisor_agent(supervisor_config, support_config, security_config, 
             
         except Exception as e:
             # Track error with LDAI metrics
-            if 'supervisor_config' in locals() and supervisor_config and hasattr(supervisor_config, 'tracker'):
-                supervisor_config.tracker.track_error()
+            supervisor_tracker.track_error()
 
             return {
                 "messages": [AIMessage(content=f"Support agent error: {e}")],

--- a/api/main.py
+++ b/api/main.py
@@ -110,7 +110,7 @@ async def submit_feedback(feedback: FeedbackRequest):
 
             # Track feedback using config_manager
             success = agent_service.config_manager.track_feedback(
-                support_config.tracker,
+                support_config.create_tracker(),
                 thumbs_up=thumbs_up
             )
 

--- a/api/services/agent_service.py
+++ b/api/services/agent_service.py
@@ -236,8 +236,9 @@ class AgentService:
             def get_variation_key(ai_config, agent_name):
                 try:
                     # The variation key is stored in the tracker object
-                    if hasattr(ai_config, 'tracker') and hasattr(ai_config.tracker, '_variation_key'):
-                        variation_key = ai_config.tracker._variation_key
+                    tracker = ai_config.create_tracker()
+                    if hasattr(tracker, '_variation_key'):
+                        variation_key = tracker._variation_key
                         log_debug(f"VARIATION EXTRACTED for {agent_name}: {variation_key}")
                         return variation_key
                     else:

--- a/config_manager.py
+++ b/config_manager.py
@@ -8,7 +8,7 @@ import json
 from pathlib import Path
 import ldclient
 from ldclient import Context
-from ldai.client import LDAIClient, LDAIAgentConfig, LDAIAgentDefaults, ModelConfig, ProviderConfig
+from ldai import LDAIClient, AIAgentConfigRequest, AIAgentConfigDefault, ModelConfig, ProviderConfig
 from ldai.tracker import FeedbackKind
 from dotenv import load_dotenv
 from utils.logger import log_student, log_debug
@@ -68,14 +68,14 @@ class FixedConfigManager:
                 "  ld-aic validate --config-keys 'supervisor-agent,support-agent,security-agent'"
             )
 
-    def _get_default_config(self, config_key: str) -> LDAIAgentDefaults:
+    def _get_default_config(self, config_key: str) -> AIAgentConfigDefault:
         """Get fallback config from .ai_config_defaults.json
 
         Args:
             config_key: The AI config key (e.g., 'support-agent')
 
         Returns:
-            LDAIAgentDefaults object with config from the defaults file
+            AIAgentConfigDefault object with config from the defaults file
 
         Raises:
             ValueError: If config key not found in defaults
@@ -93,9 +93,9 @@ class FixedConfigManager:
 
         config_data = self.config_defaults[config_key]
 
-        # Convert JSON config to LDAIAgentDefaults
+        # Convert JSON config to AIAgentConfigDefault
         # Note: Tools are managed by LaunchDarkly and not part of defaults
-        return LDAIAgentDefaults(
+        return AIAgentConfigDefault(
             enabled=config_data.get("enabled", True),
             model=ModelConfig(
                 name=config_data["model"]["name"],
@@ -207,21 +207,21 @@ class FixedConfigManager:
         default_config = self._get_default_config(ai_config_key)
         log_debug(f"CONFIG MANAGER: Loaded fallback default - model: {default_config.model.name}")
 
-        agent_config = LDAIAgentConfig(
-            key=ai_config_key,
-            default_value=default_config  # Use validated production defaults from file
+        # Call LaunchDarkly - SDK automatically falls back to default if LD unavailable
+        result = self.ai_client.agent_config(
+            ai_config_key,
+            ld_user_context,
+            default=default_config,  # Use validated production defaults from file
         )
-
-        # Call LaunchDarkly - SDK automatically falls back to default_value if LD unavailable
-        result = self.ai_client.agent(agent_config, ld_user_context)
         log_debug("CONFIG MANAGER: ✅ Got config (from LaunchDarkly or fallback)")
 
         # Debug the actual configuration received (basic info only)
         try:
             config_dict = result.to_dict()
             log_debug(f"CONFIG MANAGER: Model: {config_dict.get('model', {}).get('name', 'unknown')}")
-            if hasattr(result, 'tracker') and hasattr(result.tracker, '_variation_key'):
-                log_debug(f"CONFIG MANAGER: Variation: {result.tracker._variation_key}")
+            tracker = result.create_tracker()
+            if hasattr(tracker, '_variation_key'):
+                log_debug(f"CONFIG MANAGER: Variation: {tracker._variation_key}")
         except Exception as debug_e:
             log_debug(f"CONFIG MANAGER: Could not debug result: {debug_e}")
 
@@ -251,10 +251,11 @@ class FixedConfigManager:
         """
         try:
             # Extract metadata from agent_config for experiment attribution
+            tracker = agent_config.create_tracker()
             metadata = {
                 "version": 1,
                 "configKey": config_key,
-                "variationKey": agent_config.tracker._variation_key if hasattr(agent_config.tracker, '_variation_key') else 'unknown',
+                "variationKey": tracker._variation_key if hasattr(tracker, '_variation_key') else 'unknown',
                 "modelName": agent_config.model.name if hasattr(agent_config, 'model') else 'unknown',
                 "providerName": agent_config.provider.name if hasattr(agent_config, 'provider') else 'unknown'
             }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pydantic>=2.0.0",
     # LaunchDarkly
     "launchdarkly-server-sdk>=9.0.0",
-    "launchdarkly-server-sdk-ai>=0.1.0",
+    "launchdarkly-server-sdk-ai>=0.20.0",
     # AWS Bedrock Integration
     "langchain-aws>=0.2.0",
     "boto3>=1.35.0",


### PR DESCRIPTION
## Summary
The tutorial used a chain of pre-0.11 + pre-0.18 APIs: removed `LDAIAgentConfig`/`LDAIAgentDefaults` types, removed `ai_client.agent(...)` method, removed `config.tracker` property, and `track_latency_ms` (which never existed). Modernize to current Python AI SDK 0.20.x.

- **Type names**: `LDAIAgentConfig` → `AIAgentConfigRequest`; `LDAIAgentDefaults` → `AIAgentConfigDefault`
- **API renames**: `ai_client.agent(...)` → `ai_client.agent_config(...)`; `default_value=` → `default=` kwarg
- **Tracker factory**: hoist `tracker = config.create_tracker()` everywhere `config.tracker` was accessed
- **Method fix**: `track_latency_ms` → `track_duration` (the `hasattr` guard meant it silently no-op'd before)
- **Imports**: canonicalize `from ldai.client` → `from ldai`
- **Pin bump**: `launchdarkly-server-sdk-ai>=0.1.0` → `>=0.20.0`

Refs AIC-2383. Part of the AI Configs docs/example modernization sweep tracked in `python-agent-work/all-docs-review.md`.

## Test plan
- [ ] `python -m py_compile` on all modified files
- [ ] `pip install -e .` (or equivalent) resolves cleanly against current SDK
- [ ] Run the multi-agent demo end-to-end against `LAUNCHDARKLY_SDK_KEY`
- [ ] Final grep sweep returns zero hits for the removed-API patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)