### PR TITLE
fix: Modernize agent-graphs to AI SDK 0.20+

### DIFF
--- a/agents/generic_agent.py
+++ b/agents/generic_agent.py
@@ -41,6 +41,8 @@ def create_generic_agent(agent_config, config_manager, valid_routes: List[str] =
                 log_student(f"AGENT DISABLED: skipping")
                 return {"response": "", "_skipped": True}
 
+            tracker = agent_config.create_tracker()
+
             try:
                 # Create model from config
                 model = create_model_for_config(
@@ -83,19 +85,19 @@ def create_generic_agent(agent_config, config_manager, valid_routes: List[str] =
 
                 # Track metrics
                 duration_ms = int((time.time() - start_time) * 1000)
-                agent_config.tracker.track_duration(duration_ms)
-                agent_config.tracker.track_success()
+                tracker.track_duration(duration_ms)
+                tracker.track_success()
 
                 log_student(f"DURATION: {duration_ms}ms")
 
                 if "_token_usage" in result and result["_token_usage"]["total"] > 0:
-                    agent_config.tracker.track_tokens(TokenUsage(**result["_token_usage"]))
+                    tracker.track_tokens(TokenUsage(**result["_token_usage"]))
 
                 return result
 
             except Exception as e:
                 log_student(f"AGENT ERROR: {e}")
-                agent_config.tracker.track_error()
+                tracker.track_error()
                 return {
                     "response": f"Error: {e}",
                     "_error": str(e)

--- a/agents/ld_agent_helpers.py
+++ b/agents/ld_agent_helpers.py
@@ -239,7 +239,7 @@ async def create_agent_with_fresh_config(
             prompt=config.instructions
         )
 
-        return agent, config.tracker, False, recursion_limit
+        return agent, config.create_tracker(), False, recursion_limit
 
     except Exception as e:
         log_student(f"ERROR creating agent: {e}")
@@ -284,8 +284,8 @@ def create_simple_agent_wrapper(config_manager, config_key: str, tools: List[Any
 
                 # Use graph node tracker if available
                 active_tracker = (
-                    graph_node_config.tracker
-                    if graph_node_config and hasattr(graph_node_config, 'tracker')
+                    graph_node_config.create_tracker()
+                    if graph_node_config
                     else tracker
                 )
 

--- a/api/main.py
+++ b/api/main.py
@@ -94,7 +94,7 @@ async def submit_feedback(feedback: FeedbackRequest):
 
             # Track feedback using config_manager
             success = agent_service.config_manager.track_feedback(
-                support_config.tracker,
+                support_config.create_tracker(),
                 thumbs_up=thumbs_up
             )
 

--- a/api/services/agent_service.py
+++ b/api/services/agent_service.py
@@ -201,8 +201,10 @@ class AgentGraphExecutor:
 
         # Get variation key
         var_key = "default"
-        if hasattr(config, 'tracker') and hasattr(config.tracker, '_variation_key'):
-            var_key = config.tracker._variation_key
+        if config:
+            cfg_tracker = config.create_tracker()
+            if hasattr(cfg_tracker, '_variation_key'):
+                var_key = cfg_tracker._variation_key
 
         # Record agent config - fully generic, include all result fields
         agent_info = {
@@ -226,7 +228,7 @@ class AgentGraphExecutor:
         if not hasattr(graph_tracker, '_ld_client'):
             return
 
-        tracker = config.tracker
+        tracker = config.create_tracker()
         track_data = {
             'graphKey': graph_key,
             'configKey': getattr(tracker, '_config_key', 'unknown'),

--- a/config_manager.py
+++ b/config_manager.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 import ldclient
 from ldclient import Context
-from ldai.client import LDAIClient, AIAgentConfigDefault, ModelConfig, ProviderConfig
+from ldai import LDAIClient, AIAgentConfigDefault, ModelConfig, ProviderConfig
 from ldai.tracker import FeedbackKind
 from dotenv import load_dotenv
 from utils.logger import log_student, log_debug
@@ -207,8 +207,9 @@ class FixedConfigManager:
         try:
             config_dict = result.to_dict()
             log_debug(f"CONFIG MANAGER: Model: {config_dict.get('model', {}).get('name', 'unknown')}")
-            if hasattr(result, 'tracker') and hasattr(result.tracker, '_variation_key'):
-                log_debug(f"CONFIG MANAGER: Variation: {result.tracker._variation_key}")
+            debug_tracker = result.create_tracker()
+            if hasattr(debug_tracker, '_variation_key'):
+                log_debug(f"CONFIG MANAGER: Variation: {debug_tracker._variation_key}")
         except Exception as debug_e:
             log_debug(f"CONFIG MANAGER: Could not debug result: {debug_e}")
 
@@ -218,6 +219,18 @@ class FixedConfigManager:
     def flush(self):
         """Flush metrics and clear SDK cache"""
         self.ld_client.flush()
+
+    def clear_cache(self):
+        """Clear any cached configs (no-op for now, configs fetched live)"""
+        pass
+
+    def get_agent_graph(self, user_id: str, graph_key: str, user_context: dict = None):
+        """Get LaunchDarkly Agent Graph definition."""
+        log_debug(f"CONFIG MANAGER: Getting agent graph '{graph_key}' for user_id={user_id}")
+        ld_context = self.build_context(user_id, user_context)
+        graph = self.ai_client.agent_graph(graph_key, ld_context)
+        log_debug(f"CONFIG MANAGER: Got agent graph '{graph_key}'")
+        return graph
 
     def track_feedback(self, tracker, thumbs_up: bool):
         """Track user feedback with LaunchDarkly"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,8 @@ dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
     "pydantic>=2.10.0",
-    # LaunchDarkly (using currently available versions; update to >=10.0.0 / >=1.0.0 at GA)
     "launchdarkly-server-sdk>=9.0.0",
-    "launchdarkly-server-sdk-ai>=0.10.0",
+    "launchdarkly-server-sdk-ai>=0.20.0",
     # AWS Bedrock Integration
     "langchain-aws>=0.2.0",
     "boto3>=1.35.0",
@@ -53,6 +52,3 @@ dev = [
 
 [tool.setuptools]
 packages = ["api", "agents"]
-
-[tool.uv.sources]
-launchdarkly-server-sdk-ai = { git = "https://github.com/launchdarkly/python-server-sdk-ai", subdirectory = "packages/sdk/server-ai", rev = "main" }


### PR DESCRIPTION
## Summary

Brings `tutorial/agent-graphs` in line with the SDK modernization that landed on `main` via #24, plus two `config_manager` methods that were added to `main` in the offline-evals work (2026-04-09) but never back-ported to this branch.

### SDK migration
- `pyproject.toml`: bump `launchdarkly-server-sdk-ai` pin `>=0.10.0` → `>=0.20.0`; drop the `[tool.uv.sources]` git override pointing at `python-server-sdk-ai@main` so we install the published package.
- `config_manager.py`: canonicalize `from ldai.client` → `from ldai`.
- Replace removed `config.tracker` attribute with `config.create_tracker()` across `config_manager.py`, `agents/generic_agent.py`, `agents/ld_agent_helpers.py`, `api/services/agent_service.py`, `api/main.py`.
- In `generic_agent.py`, hoist `tracker = agent_config.create_tracker()` once so the try/except shares a single tracker (avoids creating four trackers per call).

### Pre-existing branch bug, fixed
This branch was broken at import time before this PR: `AgentService.__init__` calls `self.config_manager.clear_cache()` and `agent_service.py:50` calls `self.config_manager.get_agent_graph(...)`, but neither was defined on this branch's `FixedConfigManager`. Both methods were added on `main` (commit `dbdf4e9`, "Add offline-evals tutorial companion") and never picked up here. Ported with no logic changes.

## Test plan

- [x] Install `launchdarkly-server-sdk-ai>=0.20.0` in a fresh venv (resolves to `1.0.1`).
- [x] Import `config_manager`, `agents.ld_agent_helpers`, `agents.generic_agent`, `api.services.agent_service`, `api.main` — all succeed (previously `api.main` failed with `AttributeError: 'FixedConfigManager' object has no attribute 'clear_cache'`).
- [ ] End-to-end agent-graph run against a real LaunchDarkly project and graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)